### PR TITLE
Retry freeing a channel up to 3 times if it fails

### DIFF
--- a/lib/sftp_server/server.rb
+++ b/lib/sftp_server/server.rb
@@ -404,8 +404,20 @@ module SFTPServer
     end
 
     def free_channel(channel)
-      result = SSH::API.ssh_channel_free(channel)
-      fail SSH::API.ssh_get_error(channel) if result < 0
+      retries = 0
+
+      loop do
+        result = SSH::API.ssh_channel_free(channel)
+
+        if result >= 0
+          break
+        elsif retries >= 3
+          fail SSH::API.ssh_get_error(channel)
+        else
+          retries += 1
+          sleep 0.05
+        end
+      end
     end
 
     def disconnect_session(session)


### PR DESCRIPTION
ssh_channel_free fails quite often. Rather than immediately
raise an exception we should retry freeing the channel. This change will
retry freeing the channel up to 3 times with a 50ms wait in between.
I've found this to make our tests that use a SFTP server much more
reliable.
