### PR TITLE
Remove left-over debugging artifact

### DIFF
--- a/lib/sftp_server/server.rb
+++ b/lib/sftp_server/server.rb
@@ -1,8 +1,6 @@
 require 'sftp_server/ssh/api'
 require 'sftp_server/c/api'
 
-require 'pry'
-
 module SFTPServer
   class Server
     attr_accessor :user_name


### PR DESCRIPTION
First of all: thanx for this nifty and really helpful gem 🙏 

The server file was requiring `pry` although it's nowhere specified as a
dependency :see_no_evil: - this makes the loading the gem fail...

All in all `pry` is not really necessary to start a server, so I rather removed it then adding it as a dependency :v: hope that's fine.